### PR TITLE
Use commit action for docs build

### DIFF
--- a/.github/workflows/update-doc.yaml
+++ b/.github/workflows/update-doc.yaml
@@ -42,3 +42,4 @@ jobs:
           git add helm.md
           git commit -m "Update helm documentation from charts repository"
           git push https://${DOCS_REPO_TOKEN}@github.com/langstream/documentation.git HEAD:main
+      - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Adds stefanzweifel/git-auto-commit-action@v4commit action to fix action failure as a result of lacking git credentials.